### PR TITLE
fixing php 7.2 incompatibility issue with "count($this->include);" co…

### DIFF
--- a/src/Sportmonks/SoccerAPI/SoccerAPIClient.php
+++ b/src/Sportmonks/SoccerAPI/SoccerAPIClient.php
@@ -13,9 +13,9 @@ class SoccerAPIClient {
     protected $apiToken;
     protected $withoutData;
     protected $include = [];
+    protected $include_array = [];
     protected $perPage = 50;
     protected $page = 1;
-    protected $timezone;
     
     public function __construct()
     {
@@ -30,7 +30,6 @@ class SoccerAPIClient {
         {
             throw new \InvalidArgumentException('No API token set');
         }
-        $this->timezone = empty(config('soccerapi.timezone')) ? config('app.timezone') : config('soccerapi.timezone');
 
         $this->withoutData = empty(config('soccerapi.without_data')) ? false : config('soccerapi.without_data');
     }
@@ -42,13 +41,9 @@ class SoccerAPIClient {
             'per_page' => $this->perPage,
             'page' => $this->page
         ];
-        if(!empty($this->include))
+        if(count($this->include_array))
         {
             $query['include'] = $this->include;
-        }
-        if ($this->timezone)
-        {
-            $query['tz'] = $this->timezone;
         }
 
         $response = $this->client->get($url, ['query' => $query]);
@@ -87,6 +82,7 @@ class SoccerAPIClient {
      */
     public function setInclude($include)
     {
+        $this->include_array = $include;
         if(is_array($include) && !empty($include))
         {
             $include = implode(',', $include);

--- a/src/Sportmonks/SoccerAPI/SoccerAPIClient.php
+++ b/src/Sportmonks/SoccerAPI/SoccerAPIClient.php
@@ -16,6 +16,7 @@ class SoccerAPIClient {
     protected $include_array = [];
     protected $perPage = 50;
     protected $page = 1;
+    protected $timezone;
     
     public function __construct()
     {
@@ -30,6 +31,7 @@ class SoccerAPIClient {
         {
             throw new \InvalidArgumentException('No API token set');
         }
+        $this->timezone = empty(config('soccerapi.timezone')) ? config('app.timezone') : config('soccerapi.timezone');
 
         $this->withoutData = empty(config('soccerapi.without_data')) ? false : config('soccerapi.without_data');
     }
@@ -49,6 +51,11 @@ class SoccerAPIClient {
             }
         } elseif ( strlen($this->include_array)) {
             $query['include'] = $this->include;
+        }
+
+        if ($this->timezone)
+        {   
+            $query['tz'] = $this->timezone;
         }
 
         $response = $this->client->get($url, ['query' => $query]);

--- a/src/Sportmonks/SoccerAPI/SoccerAPIClient.php
+++ b/src/Sportmonks/SoccerAPI/SoccerAPIClient.php
@@ -41,8 +41,13 @@ class SoccerAPIClient {
             'per_page' => $this->perPage,
             'page' => $this->page
         ];
-        if(count($this->include_array))
-        {
+
+        if (is_array($this->include_array)) {
+            if(count($this->include_array))
+            {
+                $query['include'] = $this->include;
+            }
+        } elseif ( strlen($this->include_array)) {
             $query['include'] = $this->include;
         }
 


### PR DESCRIPTION
In PHP version 7.2 there's an error in regards to how you count the include variable in the SoccerAPIClient this is meant as a workaround fix for PHP 7.2 servers.

This is the error thrown:
![image](https://user-images.githubusercontent.com/26696297/43681217-fcea6792-980a-11e8-8d86-c7b35732d51a.png)

This is what the api returns afterwards:
![image](https://user-images.githubusercontent.com/26696297/43681228-2a4dff96-980b-11e8-9ac9-e8311c65c13c.png)

