### PR TITLE
Added option to add leagues as parameters and added function to TopScorers to get aggregated topscorers

### DIFF
--- a/src/Sportmonks/SoccerAPI/Requests/TopScorer.php
+++ b/src/Sportmonks/SoccerAPI/Requests/TopScorer.php
@@ -11,4 +11,9 @@ class TopScorer extends SoccerAPIClient {
         return $this->callData('topscorers/season/' . $seasonId);
     }
 
+    public function aggregatedBySeasonId($seasonId)
+    {
+        return $this->callData('topscorers/season/' . $seasonId . '/aggregated');
+    }
+
 }

--- a/src/Sportmonks/SoccerAPI/SoccerAPIClient.php
+++ b/src/Sportmonks/SoccerAPI/SoccerAPIClient.php
@@ -13,6 +13,7 @@ class SoccerAPIClient {
     protected $apiToken;
     protected $withoutData;
     protected $include = [];
+    protected $leagues = [];
     protected $perPage = 50;
     protected $page = 1;
     protected $timezone;
@@ -45,6 +46,10 @@ class SoccerAPIClient {
         if(!empty($this->include))
         {
             $query['include'] = $this->include;
+        }
+        if(!empty($this->leagues))
+        {
+            $query['leagues'] = $this->leagues;
         }
         if ($this->timezone)
         {
@@ -93,6 +98,21 @@ class SoccerAPIClient {
         }
 
         $this->include = $include;
+
+        return $this;
+    }
+
+    /**
+     * @param $leagues - string or array of leagues to only return fixtures for those leagues
+     */
+    public function setLeagues($leagues)
+    {
+        if(is_array($leagues) && !empty($leagues))
+        {
+            $leagues = implode(',', $leagues);
+        }
+
+        $this->leagues = $leagues;
 
         return $this;
     }


### PR DESCRIPTION
Added option to add leagues as parameter. This is possible for:

- fixtures between 2 dates
- fixtures between 2 dates for team
- livescores (now)
- livescores

By using this parameter, it will only return fixtures for those leagues