### PR TITLE
Function to get aggregated topscorers

### DIFF
--- a/src/Sportmonks/SoccerAPI/Requests/TopScorer.php
+++ b/src/Sportmonks/SoccerAPI/Requests/TopScorer.php
@@ -11,4 +11,9 @@ class TopScorer extends SoccerAPIClient {
         return $this->callData('topscorers/season/' . $seasonId);
     }
 
+    public function aggregatedBySeasonId($seasonId)
+    {
+        return $this->callData('topscorers/season/' . $seasonId . '/aggregated');
+    }
+
 }


### PR DESCRIPTION
Added function to TopScorer.php to get aggregated topscorers:

https://www.sportmonks.com/products/soccer/docs/2.0/topscorers/26#aggregated-topscorers-for-season

This function is usefull for cup-leagues like World Cup or Champions League